### PR TITLE
Omichi

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -3,3 +3,4 @@ DB_PORT=5434
 DB_USER=postgres
 DB_PASSWORD=postgres
 DB_NAME=postgres
+OPENAI_API_KEY=openaikey

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -5,6 +5,15 @@ import (
 	"log"
 	"net/http"
 
+	//以下を追加(12/18大道)
+	"fmt"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/sashabaranov/go-openai"
+	_ "Bot-or-Not/backend/pkg/openai"
+	//ここまで
+
 	_ "Bot-or-Not/internal/migration"
 )
 
@@ -14,4 +23,35 @@ func main() {
 	if err := http.ListenAndServe(":8080", root.Echo); err != nil {
 		log.Fatal("Error starting server: ", err)
 	}
+
+	//以下を追加(12/18大道)
+	err := godotenv.Load()
+	if err != nil{
+		log.Fatalf("Error loading .env file: %v",err)
+	}
+
+	apiKey:=os.Getenv("OPENAI_API_KEY")
+	if apiKey ==""{
+		log.Fatal("OPENAI_API_KEY not set in environment variables")
+	}
+
+	//OpenAIインスタンス作成
+	oai := openai.NewOpenAI(apiKey)
+
+	// コンテキストを用意
+	ctx := context.Background()
+
+	//実際に呼び出してみる（仮のパラメータ）
+	gameID:="game_1"
+	themaNum:=1
+	themaTxt:="「地元で驚きのイベント」が！どんなイベント？"
+
+	answer,err:=oai.GetGPTResponse(ctx, gameID,themaNum,themaTxt)
+
+	if err != nil{
+		log.Fatalf("Error from OpenAI: %v",err)
+	}
+
+	//fmt.Println("Prompt:",prompt)
+	fmt.Println("Answer:",answer)
 }

--- a/backend/pkg/openai/openai.go
+++ b/backend/pkg/openai/openai.go
@@ -20,3 +20,47 @@ func (o *OpenAI) GenerateGameTopicAIAnswer(ctx context.Context) (string, string,
 
 	return "abc", "def", nil
 }
+
+//GPTに大喜利のお題を送り、回答を生成してもらう
+//引数：ゲームID,お題num,お題txt,
+//戻り値：生成した回答
+func (o *OpenAI) GetGPTResponse(ctx context.Context, gameID string,themaNum int,themaTxt string)(string,error){
+	//プロンプト作成
+	prompt :=fmt.Sprintf(
+		"以下は大喜利ゲームのお題です。\nお題: %s\nこのお題に対して人間に負けないくらい面白い回答を一つ考えてください。",
+		gameID, themaNum,themaTxt,
+	)
+
+	//ChatCompletion API呼び出し
+	resp, err:= o.client.CreateChatCompletion(
+		ctx,
+		openai.ChatCompletionRequest{
+			Model: openai.GPT3Dot5Turbo,//ここにモデル名
+			Messages: []openai.ChatCompletionMessage{
+			{
+				Role: openai.ChatMessageRoleSystem,
+				Content: "あなたは創造的でユーモアのある大喜利回答者です。短く面白い回答のみを返してください。",
+		
+			},
+			{
+				Role: openai.ChatMessageRoleUser,
+				Content: prompt,
+		
+			},
+		},
+		Temperature: 0.7, // ユーモアや創造性を出したい場合は多少上げる
+		},
+	)
+	if err!= nil{
+		return "","", fmt.Errorf("ChatCompletion API request failed: %w", err)
+	}
+
+	if len(resp.Choices)==0{
+		return "","",fmt.Errorf("no response from GPT")
+	}
+
+	answer :=resp.Choices[0].Message.Content
+	return answer, nil
+
+	
+}

--- a/backend/pkg/openai/openai_test.go
+++ b/backend/pkg/openai/openai_test.go
@@ -1,0 +1,36 @@
+package openai
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+func TestGenerateGameTopicAIAnswer(t *testing.T) {
+	// 相対パスで.envをロード
+    err := godotenv.Load("../../.env")
+    if err != nil {
+        t.Fatalf("Failed to load .env file: %v", err)
+    }
+	
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Fatal("OPENAI_API_KEY not set")
+	}
+
+	oai := NewOpenAI(apiKey)
+	odai, answer, err := oai.GenerateGameTopicAIAnswer(context.Background())
+	if err != nil {
+		t.Fatalf("failed to generate: %v", err)
+	}
+
+	if odai == "" {
+		t.Error("odai is empty")
+	}
+	if answer == "" {
+		t.Error("answer is empty")
+	}
+	t.Logf("Odai: %s\nAnswer: %s\n", odai, answer)
+}


### PR DESCRIPTION
openai.goの関数の中身を作りました。

また、その関数単体でテストするために、openaiパッケージ内にopenai_test.goというファイルを追加しました。

実行方法は以下

・.envファイルに以下を追加
OPENAI_API_KEY="sk-????" ←discordで共有したapiキー

・ターミナルで
cd Bot-or-Not/backend　←Bot-or-Notのあるディレクトリまでいってから

・go test ./pkg/openai -v

するとターミナルでお題と回答が表示されるはず！